### PR TITLE
maint: add packaging req for camb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "packaging"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,6 @@ install_requires =
     importlib_metadata; python_version<'3.8'
     cached_property
     camb>=1.0.0
-    packaging
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
     importlib_metadata; python_version<'3.8'
     cached_property
     camb>=1.0.0
+    packaging
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Adds the `packaging` requirement for `camb`, which apparently is not listed on its own requirements.