### PR TITLE
ci: use non-deprecated gh-action-pypi-publish

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -25,6 +25,6 @@ jobs:
           python -m build .
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Fixes the PyPI CI to use v1.12.4