### PR TITLE
fix: replace deprecated _nu_info with public has_massive_nu API

### DIFF
--- a/src/hmf/cosmology/growth_factor.py
+++ b/src/hmf/cosmology/growth_factor.py
@@ -108,7 +108,7 @@ class BaseGrowthFactor(Cmpt):
 
         Or = self.cosmo.Ogamma0 + (
             self.cosmo.Onu0
-            if not self.cosmo._nu_info.has_massive_nu
+            if not self.cosmo.has_massive_nu
             else self.cosmo.Ogamma0 * self.cosmo.nu_relative_density(z)
         )
         return Or * (1 + z) ** 4 * self.cosmo.inv_efunc(z) ** 2
@@ -131,7 +131,7 @@ class BaseGrowthFactor(Cmpt):
 
         Or = self.cosmo.Ogamma0 + (
             self.cosmo.Onu0
-            if not self.cosmo._nu_info.has_massive_nu
+            if not self.cosmo.has_massive_nu
             else self.cosmo.Ogamma0 * self.cosmo.nu_relative_density(z)
         )
 


### PR DESCRIPTION
Problem

  hmf 3.6.1 is incompatible with astropy ≥ 5.0. Accessing any MassFunction property that requires the growth factor (e.g. dndlog10m, sigma) raises:

  AttributeError: 'FlatLambdaCDM' object has no attribute '_nu_info'

  The minimal reproducer:
  import hmf
  h = hmf.MassFunction(z=8.0, Mmin=5, Mmax=19, dlog10m=0.05, hmf_model="Tinker08")
  h.dndlog10m  # raises AttributeError
  
  Cause
growth_factor.py accesses the private astropy attribute _nu_info.has_massive_nu in two places (radiation_density and dlne_dlna). This internal attribute was removed in astropy
  5.0.

  Fix

  Replace self.cosmo._nu_info.has_massive_nu with the public API equivalent self.cosmo.has_massive_nu, which has been available since astropy 4.0 and is stable across versions.

  Tested with
  
  - astropy 5.3.4
  - hmf 3.6.1